### PR TITLE
Do not login and push to Docker Hub on PR from fork

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -47,7 +47,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         if: github.event.pull_request.head.repo.full_name == github.repository
 
-      - name: Build Docker image
+      - name: Build Docker image and push to Docker Hub
         id: docker_build
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -35,9 +35,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: true
-          tags: |
-            rotebeete/juntagrico:${{ steps.docker-tag.outputs.tag }}
+          push: false
         if: github.event.pull_request.head.repo.full_name != github.repository
 
       - name: Login to DockerHub
@@ -51,5 +49,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: false
+          push: true
+          tags: |
+            rotebeete/juntagrico:${{ steps.docker-tag.outputs.tag }}
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -50,6 +50,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: |
-            rotebeete/juntagrico:${{ steps.docker-tag.outputs.tag }}
+          tags: rotebeete/juntagrico:${{ steps.docker-tag.outputs.tag }}
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -36,11 +36,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event.pull_request.head.repo.full_name == github.repository
 
-      - name: Build, push and tag Docker image
+      - name: Build Docker image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+
+      - name: Build Docker image
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
           tags: |
             rotebeete/juntagrico:${{ steps.docker-tag.outputs.tag }}
+        if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Build Docker image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            rotebeete/juntagrico:${{ steps.docker-tag.outputs.tag }}
+        if: github.event.pull_request.head.repo.full_name != github.repository
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -43,12 +52,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: false
-
-      - name: Build Docker image
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: |
-            rotebeete/juntagrico:${{ steps.docker-tag.outputs.tag }}
         if: github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
Add condition to only allow login and push to Docker Hub when workflow was not triggered via PR from forked repo