### PR TITLE
start.py: Don't run makemigrations

### DIFF
--- a/start.py
+++ b/start.py
@@ -43,7 +43,6 @@ if __name__ == "__main__":
         path(BASE_DIR / environ.get('JUNTAGRICO_DATABASE_NAME')).touch()
 
     # migrations
-    call_command("makemigrations", interactive=False)
     call_command("migrate", interactive=False)
 
     # create admin


### PR DESCRIPTION
Creating migrations at startup will lead to migrations being created in
the container that are applied to the database and will be gone when the
container recreated, as they are not part of the container image.

As migrations affect the persistence in the database, they should be
versioned and provided as part of a git tree or a release and not be
created and applied on the fly without review.