### PR TITLE
GH-Actions: Drop step ids

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Extract tag from github.ref
-        id: docker-tag
         uses: yuya-takeyama/docker-tag-from-github-ref-action@v1
 
       - name: Set up QEMU
@@ -32,7 +31,6 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Build Docker image
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: false
@@ -46,7 +44,6 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
 
       - name: Build Docker image and push to Docker Hub
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true


### PR DESCRIPTION
We don't need ids on our steps, and the current configuration fails because one ID is duplicated.

Pull this out from #8 as that PR might take a bit longer and we should not leave CI broken all this time.