### PR TITLE
Re-add step id for tag extraction

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Extract tag from github.ref
+        id: docker-tag
         uses: yuya-takeyama/docker-tag-from-github-ref-action@v1
 
       - name: Set up QEMU


### PR DESCRIPTION
While I was reviewing https://github.com/Rote-Beete/juntagrico-docker/pull/17, I missed the need of `docker-tag` mentioned [here](https://github.com/Rote-Beete/juntagrico-docker/commit/07cf99a89c57e9b4733cf5deb6c2f96e26806c4b#r46787837).

We need to re-add the step id to fix the current workflow, as its accessed [later](https://github.com/Rote-Beete/juntagrico-docker/commit/07cf99a89c57e9b4733cf5deb6c2f96e26806c4b#diff-ab5b4efba7d032a7065a9d242e7e1bd92b59251ab0c5c95b4a3aa6f1d0b38db7L53)

I guess that's the reason why https://github.com/Rote-Beete/juntagrico-docker/pull/18 failed.