### PR TITLE
make USER instruction more explicit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY ["*.py", "$PROJECT_HOME/"]
 RUN chown "$USER:$GROUP" "$PROJECT_HOME/"*.py
 
 # define app user
-USER "$USER"
+USER "$USER:$GROUP"
 
 # set working directory
 WORKDIR "$PROJECT_HOME"


### PR DESCRIPTION
Run into a strange faulty state, where permission set on static was 100:101 

```shell
~/web $ ls -lan static/
total 32
drwxr-xr-x    8 100      101           4096 Jan 27 19:15 .
drwxr-xr-x    1 101      101           4096 Feb 12 11:15 ..
drwxr-xr-x    6 100      101           4096 Jan 27 19:15 admin
drwxr-xr-x    2 100      101           4096 Jan 27 19:15 css
drwxr-xr-x   11 100      101           4096 Jan 27 19:15 external
drwxr-xr-x    2 100      101           4096 Jan 27 19:15 fonts
drwxr-xr-x    6 100      101           4096 Jan 27 19:15 img
drwxr-xr-x    2 100      101           4096 Jan 27 19:15 js
~/web $
```

That's why we died trying to run `collectstatic`

```shell
juntagrico    | Traceback (most recent call last):
juntagrico    |   File "start.py", line 51, in <module>
juntagrico    |     call_command("collectstatic", interactive=False)
juntagrico    |   File "/home/app/env/lib/python3.8/site-packages/django/core/management/__init__.py", line 168, in call_command
juntagrico    |     return command.execute(*args, **defaults)
juntagrico    |   File "/home/app/env/lib/python3.8/site-packages/django/core/management/base.py", line 371, in execute
juntagrico    |     output = self.handle(*args, **options)
juntagrico    |   File "/home/app/env/lib/python3.8/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 194, in handle
juntagrico    |     collected = self.collect()
juntagrico    |   File "/home/app/env/lib/python3.8/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 118, in collect
juntagrico    |     handler(path, prefixed_path, storage)
juntagrico    |   File "/home/app/env/lib/python3.8/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 345, in copy_file
juntagrico    |     if not self.delete_file(path, prefixed_path, source_storage):
juntagrico    |   File "/home/app/env/lib/python3.8/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 298, in delete_file
juntagrico    |     self.storage.delete(prefixed_path)
juntagrico    |   File "/home/app/env/lib/python3.8/site-packages/django/core/files/storage.py", line 304, in delete
juntagrico    |     os.remove(name)
juntagrico    | PermissionError: [Errno 13] Permission denied: '/home/app/web/static/admin/fonts/README.txt'
juntagrico exited with code 1
```

~~Setting `USER` instruction to `$USER:$GROUP` fixed that state somehow..~~
Cover-Bug: See last comment